### PR TITLE
Basic, low-level permissions addition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,4 +162,4 @@ hello.py
 /node_modules
 package-lock.json
 node_files/test_mjml.mjml
-/config.py
+config.py

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -1,5 +1,3 @@
-import functools
-
 from flask import (
     redirect, render_template, url_for
 )
@@ -8,7 +6,7 @@ from flask_login import login_user, current_user, logout_user
 from app import db
 from app.auth import bp
 from app.auth.forms import LoginForm, RegisterForm
-from app.manager.db.db_interrogations import check_existing_user, insert_user
+from app.manager.db.db_interrogations import get_existing_user_by_username, insert_user
 from app.manager.db.models import User
 from app.manager.helpers import form_validated_message, form_error_message, app_endpoints
 
@@ -33,7 +31,7 @@ def register():
         password_retype = register_form.password_retype.data
         email = register_form.email.data
 
-        username_validity = check_existing_user(username)
+        username_validity = get_existing_user_by_username(username)
 
         if password == password_retype and username_validity is None:
             form_validated_message(f'User {username} has been registered. Please log in to continue')
@@ -92,14 +90,3 @@ def login():
 def logout():
     logout_user()
     return redirect(url_for(login_endpoint))
-
-
-def login_required(view):
-    @functools.wraps(view)
-    def wrapped_view(**kwargs):
-        if User.query.all() is None:
-            return redirect(url_for(login_endpoint))
-
-        return view(**kwargs)
-
-    return wrapped_view

--- a/app/blog/routes.py
+++ b/app/blog/routes.py
@@ -4,7 +4,7 @@ from flask import (
 from flask_login import current_user
 
 from app import db
-from app.auth.routes import login_required
+from app.manager.helpers import login_required
 from app.blog import bp
 from app.blog.forms import AddPost, UpdatePost
 from app.manager.db.db_interrogations import (

--- a/app/budget/routes.py
+++ b/app/budget/routes.py
@@ -9,7 +9,7 @@ from forex_python.converter import CurrencyRates
 from wtforms.validators import ValidationError
 
 from app import db
-from app.auth.routes import login_required
+from app.manager.helpers import login_required, user_roles
 from app.budget import bp
 from app.budget import forms
 from app.manager.db.db_interrogations import (
@@ -46,6 +46,7 @@ budget_template_endpoints = {
 # TODO Make sure to add form_validation_error/success to all views.
 
 @bp.route('/')
+@user_roles(permitted_roles=['admin'])
 @login_required
 def summary():
     user_id = current_user.get_id()

--- a/app/dataflow/routes.py
+++ b/app/dataflow/routes.py
@@ -4,7 +4,7 @@ from flask_dropzone import Dropzone
 from flask_wtf import FlaskForm
 from wtforms.fields import SubmitField
 
-from app.auth.routes import login_required
+from app.manager.helpers import login_required
 from app.dataflow import bp
 
 

--- a/app/manager/db/db_interrogations.py
+++ b/app/manager/db/db_interrogations.py
@@ -105,8 +105,14 @@ Database SELECT queries section
 """
 
 
-def check_existing_user(username):
+def get_existing_user_by_username(username):
     user = User.query.filter_by(username=username).first()
+
+    return user
+
+
+def get_existing_user_by_id(user_id: int):
+    user = User.query.filter_by(id=user_id).first()
 
     return user
 

--- a/app/manager/db/models.py
+++ b/app/manager/db/models.py
@@ -31,6 +31,7 @@ class User(UserMixin, db.Model):
     budget_utilities_id = db.relationship('BudgetUtilities', lazy='dynamic')
     url_decode_parse_id = db.relationship('UrlEncodeDecodeParse')
     username = db.Column(db.String(15), unique=True, nullable=False, index=True)
+    user_role = db.Column(db.String(20), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow())
     password_hash = db.Column(db.String(128))
     email = db.Column(db.String(120), index=True, unique=True)

--- a/app/manager/helpers.py
+++ b/app/manager/helpers.py
@@ -1,12 +1,17 @@
+import functools
+
 import os
 import secrets
 from datetime import datetime
 import re
 
-from flask import Flask, flash
+from flask import Flask, flash, redirect, url_for
+from flask_login import current_user
 from wtforms.validators import ValidationError
 
 from app import Config
+from app.manager.db.models import User
+from app.manager.db.db_interrogations import get_existing_user_by_id
 
 # used across many routs. Greatly helps with code cohesion. This enables a way to male sure there are no duplicate
 # constants across the application
@@ -21,6 +26,33 @@ app_endpoints = {
 }
 
 ALLOWED_EXTENSIONS = {'jpg', 'jpeg'}
+
+
+def login_required(view):
+    @functools.wraps(view)
+    def wrapped_view(**kwargs):
+        if User.query.all() is None:
+            return redirect(url_for(app_endpoints['login']))
+
+        return view(**kwargs)
+
+    return wrapped_view
+
+
+def user_roles(permitted_roles):
+    def decorator(view):
+        @functools.wraps(view)
+        def admin_view(**kwargs):
+
+            now_user_id = current_user.get_id()
+            user = get_existing_user_by_id(now_user_id)
+
+            if user.user_role not in permitted_roles:
+                return redirect(url_for(app_endpoints['login']))
+
+            return view(**kwargs)
+        return admin_view
+    return decorator
 
 
 # checks if the given filename has an extension found within the allowed filetypes.

--- a/app/manager/helpers.py
+++ b/app/manager/helpers.py
@@ -39,6 +39,14 @@ def login_required(view):
     return wrapped_view
 
 
+"""
+Basic permission grating across URLs.
+Basically, only users that have assigned roles that correspond to the argument can be given access to the wrapped view.
+@user_roles(permitted_roles=['admin', 'editor'] --> only allows users that have user.user_role field assigned with
+'admin' or 'editor'
+"""
+
+
 def user_roles(permitted_roles):
     def decorator(view):
         @functools.wraps(view)

--- a/app/manager/tests/fake_generator.py
+++ b/app/manager/tests/fake_generator.py
@@ -7,7 +7,7 @@ from flask import (
 )
 from flask_login import current_user
 
-from app.auth.routes import login_required
+from app.manager.helpers import login_required
 from app.manager import tests_bp
 from app.manager.db.db_interrogations import *
 from app.manager.helpers import form_validated_message, form_error_message, check_range

--- a/app/mrk/routes.py
+++ b/app/mrk/routes.py
@@ -9,7 +9,7 @@ from app.manager.db.db_interrogations import (
     set_gtm_container_active, set_gtm_container_inactive, inactivate_all_gtm_containers,
     get_gtm_containers, update_gtm_container_data
 )
-from app.auth.routes import login_required
+from app.manager.helpers import login_required
 from app.mrk import bp
 from app.mrk.forms import ContainerLoad
 from app.mrk.gtm_spy.gtmintel import GTMIntel

--- a/app/seo/routes.py
+++ b/app/seo/routes.py
@@ -1,7 +1,7 @@
 from flask import request, send_from_directory, render_template
 
 from app import current_app
-from app.auth.routes import login_required
+from app.manager.helpers import login_required
 from app.seo import bp
 
 
@@ -12,7 +12,6 @@ def static_from_root():
 
 
 @bp.route('/error/401')
-@login_required
 def error_401():
     pass
     return render_template('errors/401.html'), 404

--- a/app/webtools/routes.py
+++ b/app/webtools/routes.py
@@ -7,7 +7,7 @@ from flask import (
 from flask_login import current_user
 
 from app import db
-from app.auth.routes import login_required
+from app.manager.helpers import login_required
 from app.manager.db.db_interrogations import (
     add_new_url,
 )


### PR DESCRIPTION
Added access to views by using the data stored for a user in the user_role column in the database. Works by passing the view function to a decorator.

closes #58 

**Attention**: does not automatically check for `@login_required` - this is intentional.
While it is obvious that you need to be logged in to be able to have a role in viewing the function, for the moment I prefer to keep them separate.
First, this way, when exceptions arise I don't have to add `@user_roles` to every view.
Second, some views are not accessible even by logging in (API "views")

This is basically the same wrapper as the `@login_required `wrapper with the difference being that it accepts arguments and checks for user validity.